### PR TITLE
Fix bugs: collection logos, date issued dropdown values

### DIFF
--- a/src/app/browse-by/browse-by-date/browse-by-date.component.ts
+++ b/src/app/browse-by/browse-by-date/browse-by-date.component.ts
@@ -79,7 +79,7 @@ export class BrowseByDateComponent extends BrowseByMetadataComponent implements 
    * The default metadata keys to use for determining the lower limit of the StartsWith dropdown options
    */
   defaultMetadataKeys = ['dc.date.issued'];
-  preferMetadataKeys = ['dc.date.accessioned'];
+  preferMetadataKeys = ['dc.date.issued'];
 
   public constructor(
     protected route: ActivatedRoute,
@@ -118,7 +118,7 @@ export class BrowseByDateComponent extends BrowseByMetadataComponent implements 
         this.currentPagination$,
         this.currentSort$,
       ]).subscribe(([params, scope, currentPage, currentSort]: [Params, string, PaginationComponentOptions, SortOptions]) => {
-        const metadataKeys = params.browseDefinition ? params.browseDefinition.metadataKeys : this.preferMetadataKeys;
+        const metadataKeys = params.browseDefinition ? params.browseDefinition.metadataKeys : this.defaultMetadataKeys;
         this.browseId = params.id || this.defaultBrowseId;
         this.startsWith = +params.startsWith || params.startsWith;
         const searchOptions = browseParamsToOptions(params, scope, currentPage, currentSort, this.browseId, this.fetchThumbnails);

--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
@@ -1,3 +1,3 @@
 <div *ngIf="logo" class="dso-logo mb-3">
-    <img [src]="logo._links.content.href" class="w-100 img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
+    <img [src]="logo._links.content.href" class="img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
 </div>


### PR DESCRIPTION
## References
* Fixes #1
* Fixes #36 

## Description
* Updates collection logo styling so that it no longer warps small collection images
* Fixes not all years showing up in the Date Issued year dropdown

## Screenshots
<img width="1015" height="499" alt="Issue Date Year dropdown values" src="https://github.com/user-attachments/assets/281f4dcf-7377-4cae-ad2d-34eca5aa70fe" />

<img width="809" height="217" alt="Collection logo" src="https://github.com/user-attachments/assets/5d536378-4426-4da1-a2ed-bf30c11e5936" />
