### PR TITLE
Fix structural a11y issues on homepage and in header

### DIFF
--- a/src/app/home-page/top-level-community-group/top-level-community-group.component.html
+++ b/src/app/home-page/top-level-community-group/top-level-community-group.component.html
@@ -3,13 +3,9 @@
     <div class="col-md-3 text-center mb-4" *ngFor="let item of items$ | async">
       <a href="{{ item.uuid }}">
         <div class="icon-box">
-          <!-- <i [class]="item.icon"></i> -->
-          <img src="assets/images/{{ item.icon }}" alt="{{ item.label }}">
-          <h5 class="border-button united-Serif-regular">{{ item.label }}</h5>
+          <img src="assets/images/{{ item.icon }}" alt="">
+          <h2 class="border-button united-Serif-regular">{{ item.label }}</h2>
         </div>
-        <!-- <div class="label-container">
-          <span class="label">{{ item.label }}</span>
-        </div> -->
       </a>
     </div>
   </div>

--- a/src/app/home-page/top-level-community-group/top-level-community-group.component.scss
+++ b/src/app/home-page/top-level-community-group/top-level-community-group.component.scss
@@ -59,7 +59,7 @@ i {
   margin-bottom: 15px;
 }
 
-h5 {
+h2 {
   margin-top: 10px;
   font-size: 14px;
   font-weight: normal;

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
@@ -1,52 +1,64 @@
-<div class="navbar-nav mr-auto" *ngIf="(isMobile$ | async) !== true; else mobileButtons" data-test="auth-nav">
-  <div *ngIf="(isAuthenticated | async) !== true && (showAuth | async)"
-      class="nav-item"
-      (click)="$event.stopPropagation();">
-    <div ngbDropdown #loginDrop="ngbDropdown" display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="javascript:void(0);" class="dropdownLogin px-0.5" [attr.aria-label]="'nav.login' |translate"
-         (click)="$event.preventDefault()" [attr.data-test]="'login-menu' | dsBrowserOnly"
-         role="menuitem"
-         aria-haspopup="menu"
-         aria-controls="loginDropdownMenu"
-         [attr.aria-expanded]="loginDrop.isOpen()"
-         ngbDropdownToggle>{{ 'nav.login' | translate }}</a>
-      <div id="loginDropdownMenu" [ngClass]="{'pl-3 pr-3': (loading | async)}" ngbDropdownMenu
-           role="menu"
-           [attr.aria-label]="'nav.login' | translate">
-        <ds-log-in
-          [isStandalonePage]="false"></ds-log-in>
+@if ((isMobile$ | async) !== true) {
+  <div class="navbar-nav me-auto" data-test="auth-nav">
+    @if ((isAuthenticated | async) !== true && (showAuth | async)) {
+      <div
+        class="nav-item"
+        (click)="$event.stopPropagation();">
+        <div ngbDropdown #loginDrop="ngbDropdown" display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
+          <button class="dropdownLogin btn btn-link px-0" [attr.aria-label]="'nav.login' |translate"
+                  (click)="$event.preventDefault()" [attr.data-test]="'login-menu' | dsBrowserOnly"
+                  role="button"
+                  tabindex="0"
+                  aria-haspopup="menu"
+                  aria-controls="loginDropdownMenu"
+                  [attr.aria-expanded]="loginDrop.isOpen()"
+                  ngbDropdownToggle>
+            {{ 'nav.login' | translate }}
+          </button>
+          <div id="loginDropdownMenu" [ngClass]="{'ps-3 pe-3': (loading | async)}" ngbDropdownMenu
+               role="dialog"
+               aria-modal="true"
+            [attr.aria-label]="'nav.login' | translate">
+            <ds-log-in
+            [isStandalonePage]="false"></ds-log-in>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-  <div *ngIf="(isAuthenticated | async) && (showAuth | async)" class="nav-item">
-    <div ngbDropdown #loggedInDrop="ngbDropdown" display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="javascript:void(0);"
-         role="menuitem"
-         [attr.aria-label]="'nav.user-profile-menu-and-logout' | translate"
-         aria-controls="user-menu-dropdown"
-         (click)="$event.preventDefault()" [title]="'nav.user-profile-menu-and-logout' | translate"
-         class="dropdownLogout px-1"
-         [attr.data-test]="'user-menu' | dsBrowserOnly"
-         ngbDropdownToggle>
-        <i class="fas fa-user-circle fa-lg fa-fw"></i></a>
-      <div id="logoutDropdownMenu" ngbDropdownMenu>
-        <ds-user-menu [inExpandableNavbar]="false" (changedRoute)="loggedInDrop.close()"></ds-user-menu>
+    }
+    @if ((isAuthenticated | async) && (showAuth | async)) {
+      <div class="nav-item">
+        <div ngbDropdown #loggedInDrop="ngbDropdown" display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
+          <button
+            role="button"
+            tabindex="0"
+            [attr.aria-label]="'nav.user-profile-menu-and-logout' | translate"
+            aria-controls="user-menu-dropdown"
+            (click)="$event.preventDefault()" [title]="'nav.user-profile-menu-and-logout' | translate"
+            class="dropdownLogout btn btn-link px-0"
+            [attr.data-test]="'user-menu' | dsBrowserOnly"
+            ngbDropdownToggle>
+            <i class="fas fa-user-circle fa-lg fa-fw"></i>
+          </button>
+          <div id="logoutDropdownMenu" ngbDropdownMenu>
+            <ds-user-menu [inExpandableNavbar]="false" (changedRoute)="loggedInDrop.close()"></ds-user-menu>
+          </div>
+        </div>
       </div>
-    </div>
+    }
   </div>
-</div>
-
-
-<ng-template #mobileButtons>
+} @else {
   <div data-test="auth-nav">
-    <a *ngIf="(isAuthenticated | async) !== true" routerLink="/login" routerLinkActive="active" class="loginLink px-0.5" role="button">
-      {{ 'nav.login' | translate }}<span class="sr-only">(current)</span>
-    </a>
-    <a *ngIf="(isAuthenticated | async)" role="button" [attr.aria-label]="'nav.logout' |translate" [title]="'nav.logout' | translate" routerLink="/logout" routerLinkActive="active" class="logoutLink px-1">
-      <i class="fas fa-sign-out-alt fa-lg fa-fw"></i>
-      <span class="sr-only">(current)</span>
-    </a>
+     @if ((isAuthenticated | async)) {
+      <a [attr.aria-label]="'nav.logout' |translate" [title]="'nav.logout' | translate" routerLink="/logout" routerLinkActive="active" class="logoutLink px-0" role="link" tabindex="0">
+        <i class="fas fa-sign-out-alt fa-lg fa-fw"></i>
+        <span class="sr-only">(current)</span>
+      </a>
+    } @else {
+      <a routerLink="/login" routerLinkActive="active" class="loginLink px-0" role="link" tabindex="0">
+        {{ 'nav.login' | translate }}<span class="sr-only">(current)</span>
+      </a>
+    }
   </div>
-</ng-template>
+}
 
 <!-- Do not use ul/li in this menu as it breaks e2e accessibility tests -->

--- a/src/app/shared/auth-nav-menu/user-menu/user-menu.component.html
+++ b/src/app/shared/auth-nav-menu/user-menu/user-menu.component.html
@@ -1,32 +1,34 @@
-<ds-loading *ngIf="(loading$ | async)"></ds-loading>
-<ul *ngIf="(loading$ | async) !== true" class="user-menu" role="menu"
+@if ((loading$ | async)) {
+  <ds-loading></ds-loading>
+}
+@if ((loading$ | async) !== true) {
+  <ul class="user-menu" role="menu"
     [ngClass]="inExpandableNavbar ? 'user-menu-mobile pb-2 mb-2 border-bottom' : 'user-menu-dropdown'"
     [attr.aria-label]="'nav.user-profile-menu-and-logout' |translate" id="user-menu-dropdown">
-  <li class="ds-menu-item-wrapper username-email-wrapper" role="presentation">
-    {{dsoNameService.getName(user$ | async)}}<br>
-    <span class="text-muted">{{(user$ | async)?.email}}</span>
-  </li>
-  <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
-    <a class="ds-menu-item" role="menuitem"
-       [routerLink]="[profileRoute]"
-       routerLinkActive="active">{{'nav.profile' | translate}}</a>
-  </li>
-  <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
-    <a class="ds-menu-item" role="menuitem"
-       [routerLink]="[mydspaceRoute]"
-       routerLinkActive="active">{{'nav.mydspace' | translate}}</a>
-  </li>
-  <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
-    <a class="ds-menu-item" role="menuitem"
-       [routerLink]="[subscriptionsRoute]"
-       routerLinkActive="active">{{'nav.subscriptions' | translate}}</a>
-  </li>
-  <ng-container *ngIf="!inExpandableNavbar">
-    <li class="dropdown-divider" aria-hidden="true"></li>
-    <li class="ds-menu-item-wrapper" role="presentation">
-      <ds-log-out data-test="log-out-component"></ds-log-out>
+    <li class="ds-menu-item-wrapper username-email-wrapper" role="presentation">
+      {{dsoNameService.getName(user$ | async)}}<br>
+      <span class="text-muted">{{(user$ | async)?.email}}</span>
     </li>
-  </ng-container>
-</ul>
-
-
+    <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
+      <a class="ds-menu-item" role="menuitem"
+        [routerLink]="[profileRoute]"
+      routerLinkActive="active">{{'nav.profile' | translate}}</a>
+    </li>
+    <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
+      <a class="ds-menu-item" role="menuitem"
+        [routerLink]="[mydspaceRoute]"
+      routerLinkActive="active">{{'nav.mydspace' | translate}}</a>
+    </li>
+    <li class="ds-menu-item-wrapper" role="presentation" (click)="onMenuItemClick()">
+      <a class="ds-menu-item" role="menuitem"
+        [routerLink]="[subscriptionsRoute]"
+      routerLinkActive="active">{{'nav.subscriptions' | translate}}</a>
+    </li>
+    @if (!inExpandableNavbar) {
+      <li class="dropdown-divider" aria-hidden="true"></li>
+      <li class="ds-menu-item-wrapper" role="presentation">
+        <ds-log-out data-test="log-out-component"></ds-log-out>
+      </li>
+    }
+  </ul>
+}

--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -30,8 +30,8 @@
 <ng-container *ngIf="canShowDivider$ | async">
   <div class="mt-2">
     <a class="dropdown-item" *ngIf="canRegister$ | async" [routerLink]="[getRegisterRoute()]"
-       [attr.data-test]="'register' | dsBrowserOnly" role="menuitem">{{"login.form.new-user" | translate}}</a>
+       [attr.data-test]="'register' | dsBrowserOnly">{{"login.form.new-user" | translate}}</a>
     <a class="dropdown-item" *ngIf="canForgot$ | async" [routerLink]="[getForgotRoute()]"
-       [attr.data-test]="'forgot' | dsBrowserOnly" role="menuitem">{{"login.form.forgot-password" | translate}}</a>
+       [attr.data-test]="'forgot' | dsBrowserOnly">{{"login.form.forgot-password" | translate}}</a>
   </div>
 </ng-container>

--- a/src/themes/custom/app/header/header.component.html
+++ b/src/themes/custom/app/header/header.component.html
@@ -27,7 +27,7 @@
       <!-- Mobile search bar and other menus -->
       <div id="header-right" class="sb-navbar h-100 d-md-none d-flex flex-row flex-nowrap justify-content-end align-items-center gapx-1">
         <ds-search-navbar></ds-search-navbar>
-        <div role="menubar" class="h-100 d-flex flex-row flex-nowrap align-items-center gapx-1">
+        <div role="toolbar" class="h-100 d-flex flex-row flex-nowrap align-items-center gapx-1">
           <ds-lang-switch></ds-lang-switch>
           <ds-context-help-toggle></ds-context-help-toggle>
           <ds-impersonate-navbar></ds-impersonate-navbar>


### PR DESCRIPTION
## References
*  Addresses the follow points from #37 
  * Aria-required-parent: ensure elements with aria role that require parent roles are contained by them.
  * 4x redundant alternative text
  * 1x skipped heading level

## Description
Addresses a couple of issues raised by WAVE and Accessibility Insights on the Scholars' Bank home page