### PR TITLE
robots.txt: hard-code the sitemap URL

### DIFF
--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -1,7 +1,7 @@
-# The URL to the DSpace sitemaps
-# XML sitemap is listed first as it is preferred by most search engines
-Sitemap: <%= origin %>/sitemap_index.xml
-Sitemap: <%= origin %>/sitemap_index.html
+# The URL to the DSpace sitemaps. Hard-coded to avoid having to figure out
+# passing the right headers through multiple layers of reverse-proxies
+# (HAProxy, Apache, possibly TPS soon, ...)
+Sitemap: https://scholarsbank.uoregon.edu/sitemap_index.xml
 
 ##########################
 # Default Access Group


### PR DESCRIPTION
Fixes https://github.com/uoregon-libraries/scholarsbank-angular/issues/42 by hard-coding the URL so we don't have to worry about HAProxy + Apache + TPS, etc.