### PR TITLE
Replace broken links on the about page

### DIFF
--- a/src/themes/custom/app/info/about/about.component.html
+++ b/src/themes/custom/app/info/about/about.component.html
@@ -19,7 +19,7 @@
       <li>Authors select scholarly works to deposit in the archive and are responsible for insuring that deposits do not
         violate copyright laws.</li>
       <li>Authors retain <a
-          href="https://library.uoregon.edu/digital-scholarship-services/scholars-bank/faq-scholars-bank">copyright</a>
+          href="https://researchguides.uoregon.edu/scholarsbank/faq">copyright</a>
         over deposited materials (unless they sign it away to a third party)</li>
       <li> We recommend that files for submission be converted to a non-proprietary format if at all possible. For more
         guidance please see this <a href="https://researchguides.uoregon.edu/data-management/fileformats">resource</a> for
@@ -33,10 +33,10 @@
     </ul>
   
     <p>If you have any questions, check <a
-        href="https://library.uoregon.edu/digital-scholarship-services/scholars-bank/faq-scholars-bank">Frequently Asked
-        Questions</a> or contact the <a routerLink="/info/contactus">Institutional Repository Manager</a> for
+        href="https://researchguides.uoregon.edu/scholarsbank/faq">Frequently Asked
+        Questions</a> or <a routerLink="/info/contactus">contact us</a> for
       assistance. Scholars' Bank is maintained through <a
-        href="https://library.uoregon.edu/department-of-open-research">the Department of Open Research</a>.</p>
+        href="https://library.uoregon.edu/digital-library-services">Digital Library Services</a>.</p>
 
     <p>For information on accessibility accommodations at the University of Oregon, please visit the 
       <a href="https://aec.uoregon.edu/accommodations">Accessible Education Center</a>.</p>


### PR DESCRIPTION
Updates old links that have been unpublished on the about page. 

FAQ now links to [https://researchguides.uoregon.edu/scholarsbank/faq](https://researchguides.uoregon.edu/scholarsbank/faq), and DOOR has been changed to DLS.

